### PR TITLE
Bump Summoner to v2.0.1.1

### DIFF
--- a/summoner-cli.rb
+++ b/summoner-cli.rb
@@ -1,8 +1,8 @@
 class SummonerCli < Formula
   desc "CLI Tool for scaffolding batteries-included Haskell projects"
   homepage "https://kowainik.github.io/projects/summoner"
-  url "https://github.com/kowainik/summoner/releases/download/v2.0.0.0/summon-cli-osx"
-  sha256 "8f9b5e51e4365c2d0de05a51ec6e3a03351e9daff5b5e39dd0634b7ba646c04d"
+  url "https://github.com/kowainik/summoner/releases/download/v2.0.1.1/summon-cli-osx"
+  sha256 "cb18dda777d3b246c5952b62f1a4ed051804d00bfae7ebd2ffc251dea117075f"
 
   bottle :unneeded
   depends_on "hub"

--- a/summoner-cli.rb
+++ b/summoner-cli.rb
@@ -5,6 +5,7 @@ class SummonerCli < Formula
   sha256 "cb18dda777d3b246c5952b62f1a4ed051804d00bfae7ebd2ffc251dea117075f"
 
   bottle :unneeded
+  depends_on "git"
   depends_on "hub"
   conflicts_with "summoner-tui", :because => "because both install 'summon' binaries"
 

--- a/summoner-tui.rb
+++ b/summoner-tui.rb
@@ -5,6 +5,7 @@ class SummonerTui < Formula
   sha256 "442f1e9f84c69f3b6c5bc98dc7bc8a8a8550cdb8196f556c348144ba1762f897"
 
   bottle :unneeded
+  depends_on "git"
   depends_on "hub"
   conflicts_with "summoner-cli", :because => "because both install 'summon' binaries"
 

--- a/summoner-tui.rb
+++ b/summoner-tui.rb
@@ -1,8 +1,8 @@
 class SummonerTui < Formula
   desc "TUI Tool for scaffolding batteries-included Haskell projects"
   homepage "https://kowainik.github.io/projects/summoner"
-  url "https://github.com/kowainik/summoner/releases/download/v2.0.0.0/summon-tui-osx"
-  sha256 "0a264c29e142fc1bbc8b9be37aac10f896bb254558b42dc4c87c4535a4013146"
+  url "https://github.com/kowainik/summoner/releases/download/v2.0.1.1/summon-tui-osx"
+  sha256 "442f1e9f84c69f3b6c5bc98dc7bc8a8a8550cdb8196f556c348144ba1762f897"
 
   bottle :unneeded
   depends_on "hub"


### PR DESCRIPTION
Hi guys!

Thought it would be a good idea to align the Summoner formulae with the current latest version.

I'm also trying to modify Summoner to make it use the "official" GitHub CLI `gh` instead of `hub`, which would require changing the dependencies here as well. Let me know what you think!

Best regards,
David